### PR TITLE
example.ly: limit line length

### DIFF
--- a/editorial-tools/edition-engraver/example.ly
+++ b/editorial-tools/edition-engraver/example.ly
@@ -6,21 +6,36 @@
 % prepare some mods for an edition fullscore
 
 % try rehearsal marks
-\editionMod fullscore 3 2/4 my.test.Staff.A \mark \markup \with-color #blue \bold "special Mark"
-\editionMod fullscore 5 0/4 my.test.Staff.A \mark \default
-\editionMod fullscore 5 2/4 my.test.Staff.A \mark \markup \with-color #blue \bold "X"
-\editionMod fullscore 6 0/4 my.test.Staff.A \mark \default
-\editionMod fullscore 7 0/4 my.test.Staff.A \mark \default
+\editionMod fullscore 3 2/4 my.test.Staff.A
+\mark \markup \with-color #blue \bold "special Mark"
+
+\editionMod fullscore 5 0/4 my.test.Staff.A
+\mark \default
+
+\editionMod fullscore 5 2/4 my.test.Staff.A
+\mark \markup \with-color #blue \bold "X"
+
+\editionMod fullscore 6 0/4 my.test.Staff.A
+\mark \default
+
+\editionMod fullscore 7 0/4 my.test.Staff.A
+\mark \default
 
 % color the notehead red on the second quarter in the second measure
-\editionMod fullscore 2 1/4 my.test.Staff.A \once \override NoteHead #'color = #red
+\editionMod fullscore 2 1/4 my.test.Staff.A
+\once \override NoteHead #'color = #red
+
 % destroy the slur starting on the second quarter in the first measure
-\editionMod fullscore 1 2/4 my.test.Staff.A \shape #'((0 . 0)(0 . 1)(0 . -1)(0 . 0)) Slur
+\editionMod fullscore 1 2/4 my.test.Staff.A
+\shape #'((0 . 0)(0 . 1)(0 . -1)(0 . 0)) Slur
 
 % add a break to several times
-\editionMMod fullscore #'((2 1/4)) my.test.Score.A { \bar "" \break } % the empty bar permits break inside measure
+\editionMMod fullscore #'((2 1/4)) my.test.Score.A
+{ \bar "" \break } % the empty bar permits break inside measure
+
 % add an annotation in form of a TextScript
-\editionMod fullscore 2 0/4 my.test.Voice.A -\markup { \with-color #red "what's that?" }
+\editionMod fullscore 2 0/4 my.test.Voice.A
+-\markup { \with-color #red "what's that?" }
 
 % now also ottava is supported (uses context-mod-from-music)
 \editionMod fullscore 2 2/4 my.test.Staff.A \ottava #1
@@ -28,14 +43,20 @@
 
 % just another tweak on several times
 % editionMMod is still defined but should be marked deprecated
-%\editionMMod fullscore #'((1 1/4)(1 3/4)(2 2/4)) my.test.Staff.A \once \override NoteHead.color = #green
+%\editionMMod fullscore #'((1 1/4)(1 3/4)(2 2/4)) my.test.Staff.A
+%\once \override NoteHead.color = #green
+
 % editionModList is the method, which I will continue to work on
-\editionModList fullscore  my.test.Staff.A \once \override NoteHead.color = #green #'((1 1/4)(1 3/4)(2 2/4))
+\editionModList fullscore  my.test.Staff.A
+\once \override NoteHead.color = #green
+#'((1 1/4)(1 3/4)(2 2/4))
+
 
 % this places the system, starting with measure 7, absolutely
 \editionMod fullscore 7 0/1 my.test.Score.A {
   \break
-  \overrideProperty Score.NonMusicalPaperColumn.line-break-system-details #'((Y-offset . 25)(X-offset . 2))
+  \overrideProperty Score.NonMusicalPaperColumn.line-break-system-details
+  #'((Y-offset . 25)(X-offset . 2))
 }
 
 \layout {
@@ -46,7 +67,8 @@
   }
   \context {
     \Voice
-    % consist every explicitly or implicitly created voice with an edition-engraver, and inherits its tag-path from the parental staff
+    % consist every explicitly or implicitly created voice with an
+    % edition-engraver, and inherits its tag-path from the parental staff
     \consists \editionEngraver ##f
   }
 }
@@ -59,7 +81,8 @@
   \consists \editionEngraver my.test
 } <<
   \new Voice \with {
-    % add edition engraver to this voice and inherit id-path from parent context: #'(my test) from parent Staff
+    % add edition engraver to this voice and inherit id-path
+    % from parent context: #'(my test) from parent Staff
     %\consists \editionEngraver ##f
     % ... but it is already done by the layout block
   } \relative c'' { c4 bes a( g) f e' d' c \repeat unfold 20 { bes a c b } }


### PR DESCRIPTION
Lines beyond 80 characters are difficult to display in common setups, so rather have more and shorter lines.
Of course, this requires to break a single \editionMod[List] command into multiple lines, so these should be surrounded by empty lines. But I think this will remain legible or even be easier to overview.
